### PR TITLE
Re-enable LRU cache for faster performance on repeated PSF calculations

### DIFF
--- a/pandeia_coronagraphy/config.py
+++ b/pandeia_coronagraphy/config.py
@@ -16,6 +16,7 @@ class EngineConfiguration(object):
         self._on_the_fly_webbpsf_options = {}
         self._on_the_fly_webbpsf_opd = None
         self._pandeia_fixed_seed = False
+        self.verbose=False
     
     @property
     def wave_sampling(self):

--- a/pandeia_coronagraphy/engine.py
+++ b/pandeia_coronagraphy/engine.py
@@ -7,10 +7,10 @@ import pkg_resources
 import sys
 import warnings
 
-#if sys.version_info > (3, 2):
-#    from functools import lru_cache
-#else:
-#    from functools32 import lru_cache
+if sys.version_info > (3, 2):
+    from functools import lru_cache
+else:
+    from functools32 import lru_cache
 
 import numpy as np
 
@@ -34,6 +34,12 @@ from . import templates
 
 # Initialize the engine options
 options = EngineConfiguration()
+
+latest_on_the_fly_PSF = None
+cache_maxsize = 256     # Number of monochromatic PSFs stored in an LRU cache
+                        # Should speed up calculations that involve modifying things
+                        # like exposure time and don't actually require calculating new PSFs.
+
 
 def get_template(filename):
     ''' Look up a template filename.
@@ -81,7 +87,7 @@ def perform_calculation(calcfile):
     Updates to the saturation computation could go here as well.
     '''
     if options.on_the_fly_PSFs:
-        pandeia.engine.psf_library.PSFLibrary.get_psf = get_psf
+        pandeia.engine.psf_library.PSFLibrary.get_psf = get_psf_cache_wrapper
     else:
         pandeia.engine.psf_library.PSFLibrary.get_psf = pandeia_get_psf
     if options.pandeia_fixed_seed:
@@ -100,8 +106,39 @@ def perform_calculation(calcfile):
     np.random.seed(None) 
 
     return results
-    
-def get_psf(self, wave, instrument, aperture_name, source_offset=(0, 0)):
+
+
+def get_psf_cache_wrapper(self,*args,**kwargs):
+    '''
+    An additional layer to allow the use of lru_cache on
+    on-the-fly PSFs (which requires hashable inputs,
+    and should not include the 'self' argument that
+    was added in pandeia 1.1.1...
+
+    '''
+    global latest_on_the_fly_PSF
+
+
+    # Include the on-the-fly override options in the hash key for the lru_cache
+    otf_options = tuple(sorted(options.on_the_fly_webbpsf_options.items()) +
+            [options.on_the_fly_webbpsf_opd,])
+
+    # this may be needed in get_psf; extract it so we can avoid
+    # passing in 'self', which isn't hashable for the cache lookup
+    full_aperture = self._psfs[0]['aperture_name']
+
+    if options.verbose:
+        print("Getting PSF for: {}, {}, options={}, aperture={}".format( args, kwargs, otf_options, full_aperture))
+
+    tmp = get_psf(*args,**kwargs,otf_options=otf_options,
+            full_aperture=full_aperture)
+    latest_on_the_fly_PSF = deepcopy(tmp)
+    return tmp
+
+
+@lru_cache(maxsize=cache_maxsize)
+def get_psf( wave, instrument, aperture_name, source_offset=(0, 0), otf_options=None,
+        full_aperture=None):
     #Make the instrument and determine the mode
     if instrument.upper() == 'NIRCAM':
         ins = webbpsf.NIRCam()


### PR DESCRIPTION
This PR re-enables the LRU cache feature we used to have (https://github.com/kvangorkom/pandeia-coronagraphy/pull/19), with some updates  to better include all the various attributes and options that can affect the PSF properties. This should hopefully deliver faster calculations (for cases when you're computing the exact same thing multiple times), without the unreliability from incorrect cache hits that occurred before (https://github.com/kvangorkom/pandeia-coronagraphy/pull/25). 

Caveats: 
1. This doesn't work with `calculate_batch`, only with `perform_calculation`, because each subprocess will have its own empty instance of the cache rather than sharing a common cache. There seem to be ways to work around this with more complicated coding, left as a future exercise (see https://stackoverflow.com/questions/13693906/how-to-share-a-cache) 
2. The WebbPSF calculations have to be an _exact_ match for the cached results to save you time - i.e. in addition to not changing instrument properties, you can't adjust source offsets, or even regenerate a new random instance of the TA offset residuals or small grid dither pointings.  But for repeated invocations of the same scene while you fiddle with exposure times or target brightnesses or other non-scene Pandeia settings, this should save a ton of time. 
3. Most of my testing and development of this was with non-coronagraphic PSFs in my WFSC branch. I've just tested it with a MIRI calculation in the `miri_photon_noise_and_contrast.ipynb` notebook and it appears to work properly, but I'd appreciate some additional kicking of the tires before this gets merged to `master`.
