### PR TITLE
Add a few initial unit tests. Fix sign error in fourier_imshift.

### DIFF
--- a/pandeia_coronagraphy/analysis.py
+++ b/pandeia_coronagraphy/analysis.py
@@ -24,7 +24,8 @@ def klip_projection(target,reflib,truncation=10):
     proj = targflat.dot(Z.T)
     return Z.T.dot(proj).reshape(target.shape)
 
-def register_to_target(reference_image,target_image,mask=None,rescale_reference=True,return_fit=False):
+def register_to_target(reference_image, target_image, mask=None,
+        rescale_reference=True, return_fit=False, verbose=False):
     '''
     Given a reference PSF and a target image, determine the misalignment
     between the two and shift the reference onto the target.
@@ -55,6 +56,8 @@ def register_to_target(reference_image,target_image,mask=None,rescale_reference=
     centered_ref = reference_image - np.nanmean(reference_image)
     centered_targ = target_image - np.nanmean(target_image)
     offx, offy, scale = align_fourierLSQ(centered_targ, centered_ref, mask)
+    if verbose:
+        print("register_to_target: found offset = ({:.5f}, {:.5f}), scale = {:5f}".format(offx, offy, scale))
     if rescale_reference:
         registered_ref = fourier_imshift(centered_ref, -offx, -offy) / scale
     else:

--- a/pandeia_coronagraphy/tests/__init__.py
+++ b/pandeia_coronagraphy/tests/__init__.py
@@ -1,0 +1,1 @@
+# unit tests here

--- a/pandeia_coronagraphy/tests/test_analysis.py
+++ b/pandeia_coronagraphy/tests/test_analysis.py
@@ -1,0 +1,147 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import copy
+
+import pandeia_coronagraphy.analysis
+import poppy
+import webbpsf
+
+def test_register_to_target(plot=True, box=50):
+    """ Test the register_to_target function, using a simple Airy function.
+
+	See also test_register_images_nircam for a harder test case with NIRCam images
+
+    Using Airy functions, this randomly offset the 'reference' by a moderately large
+	number of integer pixels, and tests we can realign after that.
+    """
+    size = 512
+    center = (size-1)/2
+    dx = np.random.randint(-box, box)
+    dy = np.random.randint(-box, box)
+    target = poppy.misc.airy_2d(center=(center, center))   # centered PSF we will shift to match
+    ref = poppy.misc.airy_2d(center=(center+dx, center+dy))  # randomly offset PSF
+
+
+    aligned_ref, offy, offx, scale = pandeia_coronagraphy.analysis.register_to_target(ref, target, return_fit=True,
+                                                                                     rescale_reference=False)
+
+    box_min = int(size/2-box)
+    box_max = int(size/2+box)
+
+    target_zeromean = target - np.nanmean(target)  # The aligned reference is set to have zero mean,
+                                                  # so we must do the same to the target for a fair comparison.
+
+    difference = target_zeromean - aligned_ref
+
+    if plot:
+        plt.figure(figsize=(10,5))
+        plt.subplot(141)
+        plt.imshow(target)
+        plt.title("Centered Target\nat ({}, {})".format(center, center))
+        plt.subplot(142)
+        plt.imshow(ref)
+        plt.title("Offset Reference\nat ({:.2f}, {:.2f})".format(center+dx, center+dy))
+        plt.subplot(143)
+        plt.imshow(aligned_ref)
+        plt.title("Reference Aligned\nShifted by ({:.2f}, {:.2f})".format(offx, offy))
+        plt.subplot(144)
+        plt.imshow(target-aligned_ref)
+        plt.title("Diff of \nTarget - Aligned")
+
+        plt.plot( [box_min, box_min, box_max, box_max, box_min],
+                  [box_min, box_max, box_max, box_min, box_min], ls=':', color='white')
+        plt.figure()
+        plt.imshow(difference[box_min:box_max, box_min:box_max], vmin=-1e-6, vmax=1e-6)
+        plt.colorbar()
+        plt.title("Difference inside box\non different color scale!")
+
+
+
+    print("Sum of diff image:", np.abs(difference[box_min:box_max, box_min:box_max]).sum())
+    print("Box coords:", box_min, box_max)
+    print("Diff mean inside box:", difference[box_min:box_max, box_min:box_max].mean())
+    assert np.abs(difference[box_min:box_max, box_min:box_max]).sum() < target.sum()/1e4, "Image difference too large"
+    return difference
+
+def test_register_images_nircam(offset_x=None, offset_y=None, fov=6, plot=False):
+    """ Test the image registration works properly, using simulated NIRCam images
+	This is a more complicated and more realistic test case than in the
+	test_register_to_target function.
+
+	"""
+
+    # by default test for up to 1 pixel offset in any direction
+    if offset_x is None:
+        offset_x = np.random.uniform(low=-1, high=1)
+    if offset_y is None:
+        offset_y = np.random.uniform(low=-1, high=1)
+
+    nc = webbpsf.NIRCam()
+
+    nc.filter='F335M'
+    nc.image_mask='MASK335R'
+    nc.pupil_mask='MASKRND'
+
+    print("computing PSFs. Reference PSF offset by ({:.2f}, {:.2f}) pix = ({:.4f}, {:.4f}) arcsec".format(
+        offset_x, offset_y, offset_x*nc.pixelscale, offset_y*nc.pixelscale))
+    target = nc.calc_psf(nlambda=1, fov_arcsec=fov )
+
+    nc.options['source_offset_x']= offset_x * nc.pixelscale
+    nc.options['source_offset_y']= offset_y * nc.pixelscale
+    reference_offset = nc.calc_psf(nlambda=1, fov_arcsec=fov )
+
+
+    reference_aligned = copy.deepcopy(reference_offset)
+    target_zeromean = copy.deepcopy(target)
+
+    print("Aligning...")
+    for ext in [0,1]:
+        reference_aligned[ext].data, offx, offy, scale = pandeia_coronagraphy.analysis.register_to_target(
+                                                                       reference_offset[ext].data, # reference
+                                                                       target[ext].data,  # target
+                                                                       verbose=True,
+                                                                       return_fit=True,
+                                                                       rescale_reference=False)
+        print("  Ext {} offset is {:.4f}, {:.4f} pixels".format(ext, offx, offy))
+
+        if ext == 0:
+            # Compare the measured offset to the oversampled desired offset
+            sampling = reference_aligned[ext].header['OVERSAMP']
+        else:
+            sampling = 1
+        diffx = offx /sampling - offset_x
+        diffy = offy /sampling - offset_y
+        print("  Measured offset vs. applied offset residual: ({:.3f}, {:.3f}) pix".format(diffx, diffy))
+        assert np.abs(diffx) < 0.05, "Residual offset in X direction too large: {} pix".format(diffx)
+        assert np.abs(diffy) < 0.05, "Residual offset in Y direction too large: {} pix".format(diffx)
+
+
+        # Note, the aligned PSF is set to have zero mean, so do the same for the target
+        target_zeromean[ext].data -= np.nanmean(target_zeromean[ext].data)
+        #print("  Set target image's mean = 0 , too")
+
+    totdiff_before = np.abs(target[1].data - reference_offset[1].data).sum()
+    totdiff_after  = np.abs(target_zeromean[1].data - reference_aligned[1].data).sum()
+
+    print("Total residual before alignment: ", totdiff_before)
+    print("Total residual after alignment: ", totdiff_after)
+    print("Improvement factor: ", totdiff_after/totdiff_before)
+
+    assert totdiff_after < totdiff_before/4, "Image residuals didn't get enough better after alignment."
+
+    if plot:
+        # Plot the before
+        plt.figure()
+        webbpsf.display_psf_difference(target, reference_offset, title='Diff BEFORE realignment, Ext 1',
+                                       normalize=False, vmax=1e-5,
+                                       ext1=1, ext2=1)
+
+
+        # plot the after
+        plt.figure()
+        webbpsf.display_psf_difference(target_zeromean, reference_aligned, title='Diff after realignment, Ext 1',
+                                   normalize=False, vmax=1e-5,
+                                   ext1=1, ext2=1)
+
+
+

--- a/pandeia_coronagraphy/tests/test_transformations.py
+++ b/pandeia_coronagraphy/tests/test_transformations.py
@@ -1,0 +1,44 @@
+import numpy as np
+import matplotlib.pyplot as plt
+import poppy
+
+import pandeia_coronagraphy.transformations
+
+
+def test_fourier_imshift(plot=False):
+    """ Verify we can apply a random shift and the image moves in the
+    direction requested """
+    size = 512
+    center = (size-1)/2
+    dx = np.random.randint(-50, 50)
+    dy = np.random.randint(-50, 50)
+    a0 = poppy.misc.airy_2d(center=(center, center))   # centered PSF we will shift
+    a1 = poppy.misc.airy_2d(center=(center+dx, center+dy))  # target for where it should end up
+
+    # Note we have to flip the order of y and x in the call here.
+    shifted = pandeia_coronagraphy.transformations.fourier_imshift(a0, dy, dx)
+
+    difference = a1-shifted
+
+    box_min = int(size/2-50)
+    box_max = int(size/2+50)
+
+    assert np.abs(difference[box_min:box_max, box_min:box_max]).sum() < 1e-10, "Image difference too large"
+
+    if plot:
+        plt.figure(figsize=(10,5))
+        plt.subplot(141)
+        plt.imshow(a0)
+        plt.title("Centered\nat ({}, {})".format(center, center))
+        plt.subplot(142)
+        plt.imshow(a1)
+        plt.title("Centered\nat ({}, {})".format(center+dx, center+dy))
+        plt.subplot(143)
+        plt.imshow(shifted)
+        plt.title("Centered, then \n Fourer Shifted by ({}, {})".format(dx, dy))
+        plt.subplot(144)
+        plt.imshow(a1-shifted)
+        plt.title("Diff of \nlast two images".format(dx, dy))
+
+
+

--- a/pandeia_coronagraphy/transformations.py
+++ b/pandeia_coronagraphy/transformations.py
@@ -94,15 +94,15 @@ def fourier_imshift(image,xshift,yshift):
         image : nd array
             N x K image
         xshift : float
-            Pixel value by which to shift image in the x direction
+            Pixel value by which to shift image in the X axis, i.e. axis 0
         yshift : float
-            Pixel value by which to shift image in the y direction
+            Pixel value by which to shift image in the Y axis, i.e. axis 1
 
     Returns:
         offset : nd array
             Shifted image
 
     '''
-    offset = fourier_shift( np.fft.fftn(image), (-yshift,xshift) )
+    offset = fourier_shift( np.fft.fftn(image), (yshift, xshift) )
     offset = np.fft.ifftn(offset).real
     return offset


### PR DESCRIPTION
This PR adds unit tests for some of the image registration functions. In the process of doing this testing, I found and fixed a sign error in the `fourier_imshift` function. In practice for most use in this package this sign error was harmless, because it also occurred when `fourier_imshift` was called inside `align_fourierLSQ` and in effect the two sign flips cancelled out. So I do not expect this fix to actually change the output of any notebooks. But it's worth fixing since having a sign flipped on intermediate results for offset values could be confusing in some circumstances. Moreoverit would make it hard for anyone to use `fourier_imshift` directly with a shift calculated by some other method. 

Note, the new unit tests are not entirely deterministic because they generate random values (within a set range) to shift and then realign.  Locally I've ran these tests in a loop dozens of times and verified they pass repeatedly, for many different random values, but of course I cannot guarantee there isn't some chance of apparent random test failures for some small part of random number parameter space. If we see problems fro that we could consider adjusting this to instead use a deterministic set of test shifts. 