### PR TITLE
Corrected detector string input to WebbPSF

### DIFF
--- a/jwst_pancake/pandeia_subclasses.py
+++ b/jwst_pancake/pandeia_subclasses.py
@@ -279,7 +279,7 @@ class CoronagraphyPSFLibrary(PSFLibrary, object):
             ins = webbpsf.NIRCam()
             ins.filter = instrument_config['filter']
             if CoronagraphyPSFLibrary.nircam_mode[aperture_name] == 'lw_imaging':
-                ins.detector = 'A5'
+                ins.detector = 'NRCA5'
                 ins.pixelscale = ins._pixelscale_long
         elif instrument.upper() == 'MIRI':
             ins = webbpsf.MIRI()


### PR DESCRIPTION
Incorrect string being assigned to ins.detector on line 282 of pandeia_subclasses.py. Results in the following error when using on_the_fly_PSF's:

```
  File "/home/alc227/miniconda3/envs/aconda/lib/python3.7/site-packages/jwst_pancake/pandeia_subclasses.py", line 109, in get_cached_psf
    ins = CoronagraphyPSFLibrary._get_instrument(instrument, aperture_name, source_offset)
  File "/home/alc227/miniconda3/envs/aconda/lib/python3.7/site-packages/jwst_pancake/pandeia_subclasses.py", line 282, in _get_instrument
    ins.detector = 'A5'
  File "/home/alc227/miniconda3/envs/aconda/lib/python3.7/site-packages/webbpsf/webbpsf_core.py", line 1354, in detector
    raise ValueError("Invalid detector. Valid detector names are: {}".format(', '.join(self.detector_list)))
ValueError: Invalid detector. Valid detector names are: NRCA1, NRCA2, NRCA3, NRCA4, NRCA5, NRCB1, NRCB2, NRCB3, NRCB4, NRCB5
```

Adjusted 'A5' to 'NRCA5' as a result.