### PR TITLE
Add VERSION to package data

### DIFF
--- a/jwst_pancake/__init__.py
+++ b/jwst_pancake/__init__.py
@@ -13,11 +13,10 @@ try:
     with open(version_file, "r") as inf:
         __version__ = inf.readline().strip()
 except Exception as e:
-    sys.err.write("Unable to find pancake version file!\n")
+    sys.stderr.write("Unable to find pancake version file!\n")
 
 import os
 tmp = os.getenv('pandeia_refdata')
 if tmp is None:
     raise RuntimeError("ERROR - you need to set the environment variable pandeia_refdata or calculations will not work")
 del tmp
-

--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,12 @@ NAME = 'jwst_pancake'
 
 python_major = version_info[0]
 if python_major >= 3:
-    required=['numpy>=1.15','matplotlib>=2.2','pandeia.engine>=1.2', 'webbpsf>0.7', 
-              'scikit-image>=0.14', 'pysynphot>=0.9', 'astropy>=2', 'photutils>=0.5', 
+    required=['numpy>=1.15','matplotlib>=2.2','pandeia.engine>=1.2', 'webbpsf>0.7',
+              'scikit-image>=0.14', 'pysynphot>=0.9', 'astropy>=2', 'photutils>=0.5',
               'cython>=0.29', 'scipy>=1', 'poppy>0.7'],
 else:
-    required=['numpy>=1.15','matplotlib>=2.2','pandeia.engine>=1.2', 'webbpsf<0.7', 
-              'scikit-image>=0.14', 'pysynphot>=0.9', 'astropy<3', 'photutils>=0.4', 
+    required=['numpy>=1.15','matplotlib>=2.2','pandeia.engine>=1.2', 'webbpsf<0.7',
+              'scikit-image>=0.14', 'pysynphot>=0.9', 'astropy<3', 'photutils>=0.4',
               'functools32>=3', 'cython>=0.29', 'scipy>=1', 'poppy<0.7'],
 
 # Get the long description from the README file
@@ -80,7 +80,7 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=find_packages(),
-    package_data={'jwst_pancake.templates' : ['*.json']},
+    package_data={'jwst_pancake.templates' : ['*.json'], 'jwst_pancake' : ['VERSION']},
 
     # Alternatively, if you want to distribute just a my_module.py, uncomment
     # this:


### PR DESCRIPTION
After installing from master (`pip install git+https://github.com/spacetelescope/pandeia-coronagraphy.git`), importing this package fails because VERSION isn't included in the installed files, and the exception handling tries to write to sys.err, which doesn't exist.

This PR adds VERSION to package data, and changes sys.err to sys.stderr.